### PR TITLE
[NOT-FOR-UPSTREAM] platform/x86: msi-wmi-platform: Fix issue with LLVM

### DIFF
--- a/drivers/platform/x86/msi-wmi-platform.c
+++ b/drivers/platform/x86/msi-wmi-platform.c
@@ -675,12 +675,12 @@ static int msi_wmi_platform_write(struct device *dev, enum hwmon_sensor_types ty
 	u8 buffer[32] = { };
 	int ret;
 
+	guard(mutex)(&data->wmi_lock);
+
 	switch (type) {
 	case hwmon_pwm:
 		switch (attr) {
 		case hwmon_pwm_enable:
-			guard(mutex)(&data->wmi_lock);
-
 			buffer[0] = MSI_PLATFORM_AP_SUBFEATURE_FAN_MODE;
 			ret = msi_wmi_platform_query_unlocked(
 				data, MSI_PLATFORM_GET_AP, buffer,


### PR DESCRIPTION
When using LLVM you may get the following error otherwise:

```
│B│ drivers/platform/x86/msi-wmi-platform.c:718:3: error: cannot jump from switch statement to this case label
│B│   718 |                 default:
│B│       |                 ^
│B│ drivers/platform/x86/msi-wmi-platform.c:682:4: note: jump bypasses initialization of variable with __attribute__((cleanup))
│B│   682 |                         guard(mutex)(&data->wmi_lock);
│B│       |                         ^
│B│ ./include/linux/cleanup.h:419:2: note: expanded from macro 'guard'
│B│   419 |         CLASS(_name, __UNIQUE_ID(guard))
│B│       |         ^
│B│ ./include/linux/cleanup.h:300:3: note: expanded from macro 'CLASS'
│B│   300 |                 class_##_name##_constructor
│B│       |                 ^
│B│ <scratch space>:115:1: note: expanded from here
│B│   115 | class_mutex_constructor
```