### PR TITLE
[FROM-ML] HID: usbhid: skip interrupt IN polling for devices with no …

### DIFF
--- a/drivers/hid/usbhid/hid-core.c
+++ b/drivers/hid/usbhid/hid-core.c
@@ -687,7 +687,8 @@ static int usbhid_open(struct hid_device *hid)
 
 	set_bit(HID_OPENED, &usbhid->iofl);
 
-	if (hid->quirks & HID_QUIRK_ALWAYS_POLL) {
+	if ((hid->quirks & HID_QUIRK_ALWAYS_POLL) ||
+	    list_empty(&hid->report_enum[HID_INPUT_REPORT].report_list)) {
 		res = 0;
 		goto Done;
 	}


### PR DESCRIPTION
https://lore.kernel.org/linux-input/20260605113952.38435-1-yaseen@ghoul.dev/T/#u