### PR TITLE
[EXTERNALLY-MAINTAINED] drm/amd/display: Enable 3 overlay planes for Steam Deck

### DIFF
--- a/drivers/gpu/drm/amd/display/dc/dc.h
+++ b/drivers/gpu/drm/amd/display/dc/dc.h
@@ -68,7 +68,7 @@ struct dcn_dccg_reg_state;
 /**
  * MAX_SURFACES - representative of the upper bound of surfaces that can be piped to a single CRTC
  */
-#define MAX_SURFACES 4
+#define MAX_SURFACES 6
 /**
  * MAX_PLANES - representative of the upper bound of planes that are supported by the HW
  */

--- a/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
@@ -1472,9 +1472,9 @@ static bool dcn301_resource_construct(
 	dc->caps.max_cursor_size = 256;
 	dc->caps.min_horizontal_blanking_period = 80;
 	dc->caps.dmdata_alloc_size = 2048;
-	dc->caps.max_slave_planes = 2;
-	dc->caps.max_slave_yuv_planes = 2;
-	dc->caps.max_slave_rgb_planes = 2;
+	dc->caps.max_slave_planes = 3;
+	dc->caps.max_slave_yuv_planes = 3;
+	dc->caps.max_slave_rgb_planes = 3;
 	dc->caps.is_apu = true;
 	dc->caps.post_blend_color_processing = true;
 	dc->caps.force_dp_tps4_for_cp2520 = true;


### PR DESCRIPTION
From Valve's kernel, required for certain features of Gamescope to work properly.