### PR TITLE
[NOT-FOR-UPSTREAM] HID: hid-oxp: Report RGB LED under the Legion Go name

### DIFF
--- a/drivers/hid/hid-oxp.c
+++ b/drivers/hid/hid-oxp.c
@@ -1386,7 +1386,7 @@ static struct mc_subled oxp_rgb_subled_info[] = {
 
 static struct led_classdev_mc oxp_cdev_rgb = {
 	.led_cdev = {
-		.name = "oxp:rgb:joystick_rings",
+		.name = "go:rgb:joystick_rings",
 		.color = LED_COLOR_ID_RGB,
 		.brightness = 0x64,
 		.max_brightness = 0x64,


### PR DESCRIPTION
This is deliberately an OGC-carried patch and must not be sent upstream. Squatting on another device's LED name is not acceptable in mainline; the real fix belongs in the Steam client, which should match the "*:rgb:joystick_rings" suffix rather than a per-device prefix.