### PR TITLE
[NOT-FOR-UPSTREAM] HID: hid-msi: Report RGB LED under the Legion Go name

### DIFF
--- a/drivers/hid/hid-msi.c
+++ b/drivers/hid/hid-msi.c
@@ -1512,7 +1512,7 @@ static int claw_probe(struct hid_device *hdev, u8 ep)
 	if (!drvdata->bmap_support)
 		dev_dbg(&hdev->dev, "M-Key mapping is not supported. Update firmware to enable.\n");
 
-	drvdata->led_mc.led_cdev.name = "msi_claw:rgb:joystick_rings";
+	drvdata->led_mc.led_cdev.name = "go:rgb:joystick_rings";
 	drvdata->led_mc.led_cdev.brightness = 0x50;
 	drvdata->led_mc.led_cdev.max_brightness = 0x64;
 	drvdata->led_mc.led_cdev.color = LED_COLOR_ID_RGB;


### PR DESCRIPTION
This is deliberately an OGC-carried patch and must not be sent upstream. Squatting on another device's LED name is not acceptable in mainline; the real fix belongs in the Steam client, which should match the "*:rgb:joystick_rings" suffix rather than a per-device prefix.