### PR TITLE
feat: Add remaining necessary patches for deck hardware

### DIFF
--- a/drivers/bluetooth/btrtl.c
+++ b/drivers/bluetooth/btrtl.c
@@ -9,6 +9,7 @@
 #include <linux/firmware.h>
 #include <linux/unaligned.h>
 #include <linux/usb.h>
+#include <linux/dmi.h>
 
 #include <net/bluetooth/bluetooth.h>
 #include <net/bluetooth/hci_core.h>
@@ -51,6 +52,9 @@
 #define	RTL_CHIP_SUBVER (&(struct rtl_vendor_cmd) {{0x10, 0x38, 0x04, 0x28, 0x80}})
 #define	RTL_CHIP_REV    (&(struct rtl_vendor_cmd) {{0x10, 0x3A, 0x04, 0x28, 0x80}})
 #define	RTL_SEC_PROJ    (&(struct rtl_vendor_cmd) {{0x10, 0xA4, 0xAD, 0x00, 0xb0}})
+#define	RTL_IGNORE_MASK (&(struct rtl_vendor_cmd) {{0x10, 0x34, 0x60, 0x00, 0xb0}})
+
+#define	RTL_IGNORE_BT_DIS BIT(0)
 
 #define RTL_PATCH_SNIPPETS		0x01
 #define RTL_PATCH_DUMMY_HEADER		0x02
@@ -443,6 +447,34 @@ static int btrtl_vendor_read_reg16(struct hci_dev *hdev,
 
 	if (rp)
 		memcpy(rp, skb->data + 1, 2);
+
+	kfree_skb(skb);
+
+	return 0;
+}
+
+static int btrtl_vendor_write_reg16(struct hci_dev *hdev,
+				    struct rtl_vendor_cmd *cmd, const u8 * const rp)
+{
+	struct sk_buff *skb;
+	u8 buf[sizeof(*cmd) + 2];
+	int err = 0;
+
+	memcpy(buf, cmd, sizeof(*cmd));
+	memcpy(buf + sizeof(*cmd), rp, 2);
+
+	skb = __hci_cmd_sync(hdev, 0xfc62, sizeof(buf), buf, HCI_INIT_TIMEOUT);
+	if (IS_ERR(skb)) {
+		err = PTR_ERR(skb);
+		rtl_dev_err(hdev, "RTL: Write reg16 failed (%d)", err);
+		return err;
+	}
+
+	if (skb->len != 1 || skb->data[0]) {
+		bt_dev_err(hdev, "RTL: Write reg16 length mismatch");
+		kfree_skb(skb);
+		return -EIO;
+	}
 
 	kfree_skb(skb);
 
@@ -1298,8 +1330,46 @@ done:
 }
 EXPORT_SYMBOL_GPL(btrtl_download_firmware);
 
+static const struct dmi_system_id btrtl_can_ignore_bt_dis_table[] = {
+	{
+		.matches = {
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Valve"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Jupiter"),
+		},
+	},
+	{}
+};
+
+static void btrtl_handle_fw_can_ignore_bt_dis(struct hci_dev *hdev)
+{
+	u16 ignore_mask;
+	u8 buf[2];
+	int ret;
+
+	if (!dmi_check_system(btrtl_can_ignore_bt_dis_table))
+		return;
+
+	ret = btrtl_vendor_read_reg16(hdev, RTL_IGNORE_MASK, buf);
+	if (ret) {
+		rtl_dev_warn(hdev, "failed to read ignore mask, will not wake on bluetooth");
+		return;
+	}
+
+	ignore_mask = get_unaligned_le16(buf);
+	ignore_mask |= RTL_IGNORE_BT_DIS;
+	put_unaligned_le16(ignore_mask, buf);
+
+	ret = btrtl_vendor_write_reg16(hdev, RTL_IGNORE_MASK, buf);
+	if (ret)
+		rtl_dev_warn(hdev, "Failed to enable wake-on-bluetooth. (possibly due to old fw)");
+	else
+		rtl_dev_info(hdev, "wake-on-bluetooth enabled");
+}
+
 void btrtl_set_quirks(struct hci_dev *hdev, struct btrtl_device_info *btrtl_dev)
 {
+	btrtl_handle_fw_can_ignore_bt_dis(hdev);
+
 	/* Enable controller to do both LE scan and BR/EDR inquiry
 	 * simultaneously.
 	 */
@@ -1511,6 +1581,7 @@ int btrtl_get_uart_settings(struct hci_dev *hdev,
 	return 0;
 }
 EXPORT_SYMBOL_GPL(btrtl_get_uart_settings);
+
 
 MODULE_AUTHOR("Daniel Drake <drake@endlessm.com>");
 MODULE_DESCRIPTION("Bluetooth support for Realtek devices ver " VERSION);

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h
@@ -438,8 +438,6 @@ struct amdgpu_mode_info {
 	struct drm_property *regamma_tf_property;
 };
 
-#define AMDGPU_MAX_BL_LEVEL 0xFF
-
 struct amdgpu_backlight_privdata {
 	struct amdgpu_encoder *encoder;
 	uint8_t negative;

--- a/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c
+++ b/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c
@@ -39,6 +39,10 @@
 #include <linux/backlight.h>
 #include "bif/bif_4_1_d.h"
 
+
+/* Maximum backlight level. */
+#define AMDGPU_ATOM_MAX_BL_LEVEL 0xFF
+
 u8
 amdgpu_atombios_encoder_get_backlight_level_from_reg(struct amdgpu_device *adev)
 {
@@ -127,8 +131,8 @@ static u8 amdgpu_atombios_encoder_backlight_level(struct backlight_device *bd)
 	/* Convert brightness to hardware level */
 	if (bd->props.brightness < 0)
 		level = 0;
-	else if (bd->props.brightness > AMDGPU_MAX_BL_LEVEL)
-		level = AMDGPU_MAX_BL_LEVEL;
+	else if (bd->props.brightness > AMDGPU_ATOM_MAX_BL_LEVEL)
+		level = AMDGPU_ATOM_MAX_BL_LEVEL;
 	else
 		level = bd->props.brightness;
 
@@ -198,7 +202,7 @@ void amdgpu_atombios_encoder_init_backlight(struct amdgpu_encoder *amdgpu_encode
 	}
 
 	memset(&props, 0, sizeof(props));
-	props.max_brightness = AMDGPU_MAX_BL_LEVEL;
+	props.max_brightness = AMDGPU_ATOM_MAX_BL_LEVEL;
 	props.type = BACKLIGHT_RAW;
 	snprintf(bl_name, sizeof(bl_name),
 		 "amdgpu_bl%d", dev->primary->index);

--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
@@ -5229,6 +5229,7 @@ static void amdgpu_dm_backlight_set_level(struct amdgpu_display_manager *dm,
 	struct amdgpu_dm_backlight_caps *caps;
 	struct dc_link *link;
 	u32 brightness;
+	u32 prev_brightness;
 	bool rc, reallow_idle = false;
 	struct drm_connector *connector;
 
@@ -5249,7 +5250,10 @@ static void amdgpu_dm_backlight_set_level(struct amdgpu_display_manager *dm,
 	amdgpu_dm_update_backlight_caps(dm, bl_idx);
 	caps = &dm->backlight_caps[bl_idx];
 
+	prev_brightness = dm->brightness[bl_idx];
 	dm->brightness[bl_idx] = user_brightness;
+	dm->actual_brightness[bl_idx] = user_brightness;
+
 	/* update scratch register */
 	if (bl_idx == 0)
 		amdgpu_atombios_scratch_regs_set_backlight_level(dm->adev, dm->brightness[bl_idx]);
@@ -5296,8 +5300,8 @@ static void amdgpu_dm_backlight_set_level(struct amdgpu_display_manager *dm,
 
 	mutex_unlock(&dm->dc_lock);
 
-	if (rc)
-		dm->actual_brightness[bl_idx] = user_brightness;
+	if (!rc)
+		dm->actual_brightness[bl_idx] = prev_brightness;
 }
 
 static int amdgpu_dm_backlight_update_status(struct backlight_device *bd)
@@ -5413,6 +5417,7 @@ amdgpu_dm_register_backlight_device(struct amdgpu_dm_connector *aconnector)
 		backlight_device_register(bl_name, aconnector->base.kdev, dm,
 					  &amdgpu_dm_backlight_ops, &props);
 	dm->brightness[aconnector->bl_idx] = props.brightness;
+	dm->actual_brightness[aconnector->bl_idx] = props.brightness;
 
 	if (IS_ERR(dm->backlight_dev[aconnector->bl_idx])) {
 		drm_err(drm, "DM: Backlight registration failed!\n");

--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
@@ -157,6 +157,9 @@ MODULE_FIRMWARE(FIRMWARE_DCN_401_DMUB);
 #define FIRMWARE_DCN_42_DMUB "amdgpu/dcn_4_2_dmcub.bin"
 MODULE_FIRMWARE(FIRMWARE_DCN_42_DMUB);
 
+/* Maximum backlight level. */
+#define AMDGPU_MAX_BL_LEVEL 0xFFFF
+
 /**
  * DOC: overview
  *

--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
@@ -10036,6 +10036,13 @@ static void amdgpu_dm_commit_planes(struct drm_atomic_state *state,
 		struct dc_stream_update stream_update;
 	} *bundle;
 
+	/*
+	 * Hack: Make unconditional.
+	 * TODO: rework with flag to gate this or keep in in active period
+	 * based on userland selection.
+	 */
+	vrr_active = true;
+
 	bundle = kzalloc_obj(*bundle);
 
 	if (!bundle) {


### PR DESCRIPTION
* Bluetooth wake-from-suspend support
* Backlight precision bump, may help with LGO2
* Backlight change stutter fix
* Required vblank fix for the gamescope session, without it setting 60hz will give a 30fps limit, and other oddities

All from SteamOS linux-integration repo