### PR TITLE
[FROM-ML] HID: asus: do not send keyboard init reports to touchpads

### DIFF
--- a/drivers/hid/hid-asus.c
+++ b/drivers/hid/hid-asus.c
@@ -1314,12 +1314,14 @@ static int asus_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		return ret;
 	}
 
-	for (int r = 0; r < ARRAY_SIZE(asus_report_id_init); r++) {
-		if (asus_has_report_id(hdev, asus_report_id_init[r])) {
-			ret = asus_kbd_init(hdev, asus_report_id_init[r]);
-			if (ret < 0)
-				hid_warn(hdev, "Failed to initialize 0x%x: %d.\n",
-					 asus_report_id_init[r], ret);
+	if (!drvdata->tp) {
+		for (int r = 0; r < ARRAY_SIZE(asus_report_id_init); r++) {
+			if (asus_has_report_id(hdev, asus_report_id_init[r])) {
+				ret = asus_kbd_init(hdev, asus_report_id_init[r]);
+				if (ret < 0)
+					hid_warn(hdev, "Failed to initialize 0x%x: %d.\n",
+						 asus_report_id_init[r], ret);
+			}
 		}
 	}
 


### PR DESCRIPTION
Sending keyboard initialization packets to touchpads messes them up: I forgot to exclude those devices when I reworked hid-asus and the commit author has sent a fix.

Link v2: https://lore.kernel.org/all/20260818152901.B5D781F00A3D@smtp.kernel.org/
Link v1: https://lore.kernel.org/all/20260818085623.18467-1-panz.development@gmail.com/