### PR TITLE
[FROM-ML] platform/x86: asus-armoury: fix notifications for grouped attributes

### DIFF
--- a/drivers/platform/x86/asus-armoury.c
+++ b/drivers/platform/x86/asus-armoury.c
@@ -127,10 +127,10 @@ static ssize_t pending_reboot_show(struct kobject *kobj, struct kobj_attribute *
 
 static struct kobj_attribute pending_reboot = __ATTR_RO(pending_reboot);
 
-static bool asus_bios_requires_reboot(struct kobj_attribute *attr)
+static bool asus_bios_requires_reboot(const char *fsname)
 {
-	return !strcmp(attr->attr.name, "gpu_mux_mode") ||
-	       !strcmp(attr->attr.name, "panel_hd_mode");
+	return !strcmp(fsname, "gpu_mux_mode") ||
+	       !strcmp(fsname, "panel_hd_mode");
 }
 
 /**
@@ -314,7 +314,7 @@ ssize_t armoury_attr_uint_store(struct kobject *kobj, struct kobj_attribute *att
 		*store_value = value;
 	sysfs_notify(kobj, fsname, attr->attr.name);
 
-	if (asus_bios_requires_reboot(attr))
+	if (asus_bios_requires_reboot(fsname))
 		asus_set_reboot_and_signal_event();
 
 	return count;

--- a/drivers/platform/x86/asus-armoury.c
+++ b/drivers/platform/x86/asus-armoury.c
@@ -294,7 +294,7 @@ static int armoury_attr_enum_list(char *buf, size_t enum_values)
 
 ssize_t armoury_attr_uint_store(struct kobject *kobj, struct kobj_attribute *attr,
 				const char *buf, size_t count, u32 min, u32 max,
-				u32 *store_value, u32 wmi_dev)
+				u32 *store_value, u32 wmi_dev, const char *fsname)
 {
 	u32 value;
 	int err;
@@ -312,7 +312,7 @@ ssize_t armoury_attr_uint_store(struct kobject *kobj, struct kobj_attribute *att
 
 	if (store_value != NULL)
 		*store_value = value;
-	sysfs_notify(kobj, NULL, attr->attr.name);
+	sysfs_notify(kobj, fsname, attr->attr.name);
 
 	if (asus_bios_requires_reboot(attr))
 		asus_set_reboot_and_signal_event();
@@ -442,7 +442,8 @@ static ssize_t mini_led_mode_current_value_store(struct kobject *kobj,
 
 	return armoury_attr_uint_store(kobj, attr, mapped_value, count, 0,
 				       mini_led_mode_map[mode], NULL,
-				       asus_armoury.mini_led_dev_id);
+				       asus_armoury.mini_led_dev_id,
+				       "mini_led_mode");
 }
 
 static ssize_t mini_led_mode_possible_values_show(struct kobject *kobj,
@@ -495,7 +496,7 @@ static ssize_t gpu_mux_mode_current_value_store(struct kobject *kobj,
 	if (err)
 		return err;
 
-	sysfs_notify(kobj, NULL, attr->attr.name);
+	sysfs_notify(kobj, "gpu_mux_mode", attr->attr.name);
 	asus_set_reboot_and_signal_event();
 
 	return count;
@@ -530,7 +531,7 @@ static ssize_t dgpu_disable_current_value_store(struct kobject *kobj,
 			return err;
 	}
 
-	sysfs_notify(kobj, NULL, attr->attr.name);
+	sysfs_notify(kobj, "dgpu_disable", attr->attr.name);
 
 	return count;
 }
@@ -652,7 +653,7 @@ static ssize_t egpu_enable_current_value_store(struct kobject *kobj, struct kobj
 	 */
 	armoury_pci_rescan();
 
-	sysfs_notify(kobj, NULL, attr->attr.name);
+	sysfs_notify(kobj, "egpu_enable", attr->attr.name);
 
 	return count;
 }
@@ -746,7 +747,7 @@ static ssize_t apu_mem_current_value_store(struct kobject *kobj, struct kobj_att
 	}
 
 	pr_info("APU memory changed to %uGB, reboot required\n", requested + 1);
-	sysfs_notify(kobj, NULL, attr->attr.name);
+	sysfs_notify(kobj, "apu_mem", attr->attr.name);
 
 	asus_set_reboot_and_signal_event();
 

--- a/drivers/platform/x86/asus-armoury.h
+++ b/drivers/platform/x86/asus-armoury.h
@@ -25,6 +25,7 @@
  * @max: Maximum accepted value. Above this returns -EINVAL.
  * @store_value: Pointer to where the parsed value should be stored.
  * @wmi_dev: The WMI function ID to use.
+ * @fsname: The name of the attribute's group directory, for sysfs_notify().
  *
  * This function is intended to be generic so it can be called from any "_store"
  * attribute which works only with integers.
@@ -40,7 +41,7 @@
  */
 ssize_t armoury_attr_uint_store(struct kobject *kobj, struct kobj_attribute *attr,
 				const char *buf, size_t count, u32 min, u32 max,
-				u32 *store_value, u32 wmi_dev);
+				u32 *store_value, u32 wmi_dev, const char *fsname);
 
 /**
  * armoury_attr_uint_show() - Receive an uint from a WMI method.
@@ -72,13 +73,13 @@ ssize_t armoury_attr_uint_show(struct kobject *kobj, struct kobj_attribute *attr
 #define __ASUS_ATTR_RW(_func, _name) \
 	__ATTR(_name, 0644, _func##_##_name##_show, _func##_##_name##_store)
 
-#define __WMI_STORE_INT(_attr, _min, _max, _wmi)				\
+#define __WMI_STORE_INT(_attr, _min, _max, _wmi, _fsname)			\
 	static ssize_t _attr##_store(struct kobject *kobj,			\
 				     struct kobj_attribute *attr,		\
 				     const char *buf, size_t count)		\
 	{									\
 		return armoury_attr_uint_store(kobj, attr, buf, count, _min,	\
-					_max, NULL, _wmi);			\
+					_max, NULL, _wmi, _fsname);		\
 	}
 
 #define ASUS_WMI_SHOW_INT(_attr, _wmi)						\
@@ -121,7 +122,8 @@ ssize_t armoury_attr_uint_show(struct kobject *kobj, struct kobj_attribute *attr
 
 #define __ATTR_RW_INT_GROUP_ENUM(_attrname, _minv, _maxv, _wmi, _fsname,\
 				 _possible, _dispname)			\
-	__WMI_STORE_INT(_attrname##_current_value, _minv, _maxv, _wmi);	\
+	__WMI_STORE_INT(_attrname##_current_value, _minv, _maxv, _wmi,	\
+			_fsname);					\
 	ASUS_WMI_SHOW_INT(_attrname##_current_value, _wmi);	\
 	static struct kobj_attribute attr_##_attrname##_current_value =	\
 		__ASUS_ATTR_RW(_attrname, current_value);		\
@@ -251,7 +253,7 @@ ssize_t armoury_attr_uint_show(struct kobject *kobj, struct kobj_attribute *attr
 	static struct kobj_attribute attr_##_attrname##_default_value =		\
 		__ASUS_ATTR_RO(_attrname, default_value)
 
-#define __ROG_TUNABLE_RW(_attr, _wmi)						\
+#define __ROG_TUNABLE_RW(_attr, _wmi, _fsname)					\
 	static ssize_t _attr##_current_value_store(				\
 		struct kobject *kobj, struct kobj_attribute *attr,		\
 		const char *buf, size_t count)					\
@@ -268,7 +270,7 @@ ssize_t armoury_attr_uint_show(struct kobject *kobj, struct kobj_attribute *attr
 		return armoury_attr_uint_store(kobj, attr, buf, count,		\
 				       tunables->power_limits->_attr##_min,	\
 				       tunables->power_limits->_attr##_max,	\
-				       &tunables->_attr, _wmi);			\
+				       &tunables->_attr, _wmi, _fsname);	\
 	}									\
 	static ssize_t _attr##_current_value_show(				\
 		struct kobject *kobj, struct kobj_attribute *attr, char *buf)	\
@@ -284,7 +286,7 @@ ssize_t armoury_attr_uint_show(struct kobject *kobj, struct kobj_attribute *attr
 		__ASUS_ATTR_RW(_attr, current_value)
 
 #define ASUS_ATTR_GROUP_ROG_TUNABLE(_attrname, _fsname, _wmi, _dispname)	\
-	__ROG_TUNABLE_RW(_attrname, _wmi);				\
+	__ROG_TUNABLE_RW(_attrname, _wmi, _fsname);			\
 	__ROG_TUNABLE_SHOW_DEFAULT(_attrname);				\
 	__ROG_TUNABLE_SHOW(min_value, _attrname, _attrname##_min);	\
 	__ROG_TUNABLE_SHOW(max_value, _attrname, _attrname##_max);	\


### PR DESCRIPTION
Both fixes are the same mistake: the code identifies an attribute by
attr->attr.name, but callers always pass a current_value attribute, and
that name is always "current_value". sysfs_notify() therefore resolves
nothing, and asus_bios_requires_reboot() never matches.

Patch 1 threads the group name down to the notify calls; patch 2 uses
it for the reboot check, so it needs patch 1.

Ahmed Yaseen (2):

- platform/x86: asus-armoury: fix sysfs_notify() of grouped attributes
- platform/x86: asus-armoury: fix pending_reboot for grouped attributes

---

Applied with `b4` from the mailing list.
Link: https://lore.kernel.org/all/20260828111232.74443-1-yaseen@ghoul.dev/