### PR TITLE
[FROM-UPSTREAM] Bluetooth: btusb: Add new VID/PID 0x0489/0xe156 for MT7902

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -679,6 +679,8 @@ static const struct usb_device_id quirks_table[] = {
 	{ USB_DEVICE(0x13d3, 0x3606), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	/* MediaTek MT7902 Bluetooth devices */
+	{ USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x0e8d, 0x1ede), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |


### PR DESCRIPTION
## Summary
- Backport upstream `btusb` USB ID for MediaTek MT7902 Bluetooth (`0489:e156`)
- Without this quirk, HCI init times out with `Opcode 0x0c03 failed: -110`
- Fixes the breakage reported in #112

## Upstream
- Commit: https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git/commit/?id=8ec03dcf98f985c5c9b512d7e8d04911bce1cf21
- Title: `Bluetooth: btusb: Add new VID/PID 0x0489/0xe156 for MT7902` (Sean Wang)

## Test plan
- [x] Confirmed stock OGC `btusb` lacks `0489:e156` and fails HCI init (`Opcode 0x0c03 failed: -110`)
- [x] Confirmed a `btusb` build including this ID as `BTUSB_MEDIATEK` enumerates the controller successfully
- [ ] Verify on OGC/`bazzite-deck-nvidia:testing` kernel once merged

Closes #112

Made with [Cursor](https://cursor.com)